### PR TITLE
refactor: remove neat-annotations link tag and homepage project link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,6 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Plus+Jakarta+Sans:wght@500;600;700;800&family=Shantell+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap" rel="stylesheet">
 
     <!-- Stylesheets (with cache-busting timestamp) -->
-    <link rel="stylesheet" href="/css/neat-annotations.css?v={{ site.time | date: '%s' }}" type="text/css" />
     <link rel="stylesheet" href="/css/syntax.css?v={{ site.time | date: '%s' }}" type="text/css" />
     <link rel="stylesheet" href="/css/screen.css?v={{ site.time | date: '%s' }}" type="text/css" />
 

--- a/css/screen.css
+++ b/css/screen.css
@@ -1,6 +1,7 @@
 /*****************************************************************************/
 /* 42DevOps Modern Theme - Sleek, Compact & Refined Design                  */
 /*****************************************************************************/
+@import url('neat-annotations.css');
 
 :root {
   --font-sans: 'Plus Jakarta Sans', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;

--- a/index.html
+++ b/index.html
@@ -78,21 +78,6 @@ title: "42DevOps | Infrastructure & Engineering Notes"
         View on GitHub &rarr;
       </div>
     </a>
-
-    <a href="https://github.com/syabro/neat-annotations" target="_blank" rel="noopener" class="project-card">
-      <div>
-        <div class="project-name">
-          <span>✨ Neat Annotations</span>
-          <span class="tag-badge" style="background: rgba(147, 51, 234, 0.15); color: var(--ann-purple);">Design</span>
-        </div>
-        <p class="project-desc">
-          Hand-drawn CSS annotations for inline text highlighting, custom directional arrows, and handwritten notes.
-        </p>
-      </div>
-      <div style="margin-top: 1rem; font-size: 0.8rem; color: var(--brand-primary); font-weight: 600;">
-        View Theme Library &rarr;
-      </div>
-    </a>
   </div>
 </section>
 


### PR DESCRIPTION
This PR removes the standalone neat-annotations stylesheet link tag from default.html (importing it inside screen.css instead) and removes the neat-annotations project card link from index.html.