### PR TITLE
fix: add LaTeX delimiters to KaTeX auto-render configuration

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.css" crossorigin="anonymous">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.js" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/contrib/auto-render.min.js" crossorigin="anonymous"
-            onload="renderMathInElement(document.body, {delimiters: [{left: '$$', right: '$$', display: true}, {left: '$', right: '$', display: false}]});"></script>
+            onload="renderMathInElement(document.body, {delimiters: [{left: '$$', right: '$$', display: true}, {left: '$', right: '$', display: false}, {left: '\\\[', right: '\\\]', display: true}, {left: '\\\(', right: '\\\)', display: false}], throwOnError: false});"></script>
 
     <!-- Theme Initialization Script (Avoid Flash of Unstyled Theme) -->
     <script>


### PR DESCRIPTION
This PR updates the KaTeX auto-render options in default.html to support LaTeX delimiters \[ ... \] and \( ... \). This allows Kramdown-generated math blocks to be properly parsed and rendered into KaTeX formulas.