### PR TITLE
perf: streamline Google Fonts loading

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Noto+Serif+SC:wght@400;500;600;700&family=Plus+Jakarta+Sans:wght@500;600;700;800&family=Shantell+Sans:ital,wght@0,400;0,500;0,600;1,400&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,500;0,8..60,600;1,8..60,400&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Noto+Serif+SC:wght@400;500;600;700&family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Shantell+Sans:wght@400;500;600;700&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,500;0,8..60,600;1,8..60,400&display=swap" rel="stylesheet">
 
     <!-- Stylesheets (with cache-busting timestamp) -->
     <link rel="stylesheet" href="/css/syntax.css?v={{ site.time | date: '%s' }}" type="text/css" />


### PR DESCRIPTION
This PR optimizes the Google Fonts request:
- Removed the redundant `Inter` font request (which was only acting as a fallback).
- Simplified font weights for `Shantell Sans` and `Plus Jakarta Sans` to only request the weights actually used in the CSS.
- This reduces the overall CSS payload and external requests, improving First Contentful Paint (FCP).